### PR TITLE
Add cross-compilation support and refactor build process

### DIFF
--- a/pkg/config-file.go
+++ b/pkg/config-file.go
@@ -12,20 +12,22 @@ type Config struct {
 				Env   struct {
 					GOENV string `yaml:"GO_ENV"`
 				} `yaml:"env"`
-				Output           string   `yaml:"output"`
-				Tags             []string `yaml:"tags"`
-				Ldflags          string   `yaml:"ldflags"`
-				CrossCompilation []string `yaml:"cross-compilation"`
+				Output   string   `yaml:"output"`
+				Tags     []string `yaml:"tags"`
+				Ldflags  string   `yaml:"ldflags"`
+				OsTarget string   `yaml:"os-target"`
+				Arch     string   `yaml:"arch"`
 			} `yaml:"debug"`
 			Release struct {
 				Flags []string `yaml:"flags"`
 				Env   struct {
 					GOENV string `yaml:"GO_ENV"`
 				} `yaml:"env"`
-				Output           string   `yaml:"output"`
-				Tags             []string `yaml:"tags"`
-				Ldflags          string   `yaml:"ldflags"`
-				CrossCompilation []string `yaml:"cross-compilation"`
+				Output   string   `yaml:"output"`
+				Tags     []string `yaml:"tags"`
+				Ldflags  string   `yaml:"ldflags"`
+				OsTarget string   `yaml:"os-target"`
+				Arch     string   `yaml:"arch"`
 			} `yaml:"release"`
 		} `yaml:"profiles"`
 	} `yaml:"build"`

--- a/src/build.go
+++ b/src/build.go
@@ -12,6 +12,7 @@ import (
 )
 
 var profileName string
+var crossCompilation bool
 
 var buildUsage = `Build LezGo with given profile.
 
@@ -19,6 +20,7 @@ Usage: lezgo build [OPTIONS]
 
 Options:
 	-p, --profile     give the name of the profile
+	-c, --cross-compilation     tell if the build should be using the cross-compilation option of the profile 
 `
 
 var buildFunc = func(cmd *Command, args []string) {
@@ -98,6 +100,8 @@ func NewBuildCommand() *Command {
 
 	cmd.flags.StringVar(&profileName, "profile", "", "Long declaration to give the name of the profile")
 	cmd.flags.StringVar(&profileName, "p", "", "Short declaration to give the name of the profile")
+	cmd.flags.BoolVar(&crossCompilation, "cross-compilation", false, "Long declaration to activate the cross-compilation option of the given profile")
+	cmd.flags.BoolVar(&crossCompilation, "c", false, "Short declaration to activate the cross-compilation option of the given profile")
 
 	cmd.flags.Usage = func() {
 		fmt.Fprintln(os.Stderr, initUsage)

--- a/src/templates/lezgo-config.template.go
+++ b/src/templates/lezgo-config.template.go
@@ -16,7 +16,8 @@ build:
         GO_ENV: debug
       output: ./bin/debug/
       tags: ["debug"]
-      cross-compilation: [""]
+      os-target: darwin
+      arch: arm64
 
     release:
       flags: ["-ldflags", "-s -w"]
@@ -24,6 +25,7 @@ build:
         GO_ENV: production
       output: ./bin/release/
       tags: ["release"]
-      cross-compilation: [""]`
+      os-target: darwin
+      arch: arm64`
 	return fmt.Sprintf(configTemplate, name)
 }


### PR DESCRIPTION
Introduce cross-compilation flags and enhance build profiles with OS target and architecture fields. Simplify the build process by extracting profile-specific logic and improve logging consistency.